### PR TITLE
Phase 1: MVP Telegram bot core commands

### DIFF
--- a/aiogram/__init__.py
+++ b/aiogram/__init__.py
@@ -41,23 +41,70 @@ class _MessageRegistry:
 
 class Dispatcher:
     """Minimal dispatcher that accepts handler registration and polling."""
+
     def __init__(self) -> None:
         self.message = _MessageRegistry()
+        self.callback_query = _CallbackRegistry()
 
     async def start_polling(self, bot: Bot) -> None:
         # Polling is no‑op in stub
         await asyncio.sleep(0)
 
 
+class _CallbackRegistry:
+    """Simplified registry for callback query handlers."""
+
+    def __init__(self) -> None:
+        self._handlers: list[Callable[..., Any]] = []
+
+    def register(self, handler: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
+        self._handlers.append(handler)
+
+
 class types:  # type: ignore
+    class User:
+        """Minimal user representation used by messages and callbacks."""
+
+        def __init__(self, id: int) -> None:
+            self.id = id
+
     class Message:
         """Represents a Telegram message in the stub."""
-        def __init__(self, text: str = "") -> None:
+
+        def __init__(self, text: str = "", from_user: "types.User" | None = None) -> None:
+            self.text = text
+            self.from_user = from_user or types.User(0)
+
+        async def answer(self, text: str, reply_markup: Any | None = None) -> None:
+            pass
+
+        async def edit_text(self, text: str) -> None:
             self.text = text
 
-        async def answer(self, text: str) -> None:
-            # In tests we might capture answers; for now this is a no‑op.
+    class CallbackQuery:
+        """Stub for callback queries."""
+
+        def __init__(
+            self,
+            data: str,
+            message: "types.Message",
+            from_user: "types.User" | None = None,
+        ) -> None:
+            self.data = data
+            self.message = message
+            self.from_user = from_user or message.from_user
+
+        async def answer(self) -> None:  # pragma: no cover - no logic
             pass
+
+    class InlineKeyboardButton:
+        def __init__(self, text: str, callback_data: str) -> None:
+            self.text = text
+            self.callback_data = callback_data
+
+    class InlineKeyboardMarkup:
+        def __init__(self, inline_keyboard: Any) -> None:
+            self.inline_keyboard = inline_keyboard
 
     class CommandObject:
         """Placeholder for aiogram CommandObject."""

--- a/hyperliquid_bot/api/metrics.py
+++ b/hyperliquid_bot/api/metrics.py
@@ -1,0 +1,29 @@
+"""Simple in-memory metrics helpers for tests."""
+from __future__ import annotations
+
+from typing import Dict
+
+_latency_buckets = [50, 100, 250, 500]
+latency_ms_bucket: Dict[int, int] = {b: 0 for b in _latency_buckets}
+_total_orders = 0
+
+
+def observe_latency(ms: float) -> None:
+    """Record a handler latency in milliseconds."""
+    for b in _latency_buckets:
+        if ms <= b:
+            latency_ms_bucket[b] += 1
+            break
+
+
+def inc_orders() -> None:
+    """Increment total order counter."""
+    global _total_orders
+    _total_orders += 1
+
+
+def render_metrics() -> str:
+    """Render metrics in Prometheus text format."""
+    lines = [f'latency_ms_bucket{{le="{b}"}} {latency_ms_bucket[b]}' for b in _latency_buckets]
+    lines.append(f'total_orders {_total_orders}')
+    return "\n".join(lines) + "\n"

--- a/hyperliquid_bot/bot/db.py
+++ b/hyperliquid_bot/bot/db.py
@@ -10,13 +10,43 @@ from __future__ import annotations
 
 from typing import Optional
 
-from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
-from sqlalchemy.orm import declarative_base
+from sqlalchemy import Column, Float, ForeignKey, Integer, String, select
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.orm import declarative_base, relationship
 
 from .config import Settings
 
 
 Base = declarative_base()
+
+
+class User(Base):
+    """Database model representing a Telegram user."""
+
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    telegram_id = Column(Integer, unique=True, index=True)
+    country = Column(String, nullable=True)
+    trades = relationship("Trade", back_populates="user")
+
+
+class Trade(Base):
+    """Model representing a confirmed trade."""
+
+    __tablename__ = "trades"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    symbol = Column(String)
+    side = Column(String)
+    size = Column(Float)
+    user = relationship("User", back_populates="trades")
 
 
 def get_engine(settings: Optional[Settings] = None) -> AsyncEngine:
@@ -34,3 +64,22 @@ def get_engine(settings: Optional[Settings] = None) -> AsyncEngine:
     """
     s = settings or Settings()
     return create_async_engine(s.database_url, echo=False, future=True)
+
+
+def get_sessionmaker(settings: Optional[Settings] = None) -> async_sessionmaker[AsyncSession]:
+    """Return an async session factory bound to the engine."""
+
+    engine = get_engine(settings)
+    return async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def get_or_create_user(session: AsyncSession, telegram_id: int) -> User:
+    """Fetch a user by Telegram ID, creating one if missing."""
+
+    result = await session.execute(select(User).where(User.telegram_id == telegram_id))
+    user = result.scalar_one_or_none()
+    if user is None:
+        user = User(telegram_id=telegram_id)
+        session.add(user)
+        await session.flush()
+    return user

--- a/hyperliquid_bot/bot/middleware.py
+++ b/hyperliquid_bot/bot/middleware.py
@@ -13,6 +13,8 @@ import time
 from typing import Any, Awaitable, Callable, Dict
 
 
+from ..api.metrics import observe_latency
+
 logger = logging.getLogger(__name__)
 
 
@@ -36,4 +38,5 @@ class ExecutionTimeMiddleware:
         duration = time.perf_counter() - start
         data["execution_time"] = duration
         logger.info("%s handled in %.4f seconds", getattr(handler, "__name__", str(handler)), duration)
+        observe_latency(duration * 1000)
         return result

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,0 +1,15 @@
+from hyperliquid_bot.bot import hyperliquid
+
+
+def test_circuit_breaker_trips(monkeypatch):
+    hyperliquid._error_times.clear()
+    hyperliquid._paused_until = 0
+    times = [0, 10, 20, 21]
+
+    def fake_monotonic():
+        return times.pop(0)
+
+    monkeypatch.setattr(hyperliquid.time, "monotonic", fake_monotonic)
+    for _ in range(3):
+        hyperliquid.record_api_error()
+    assert hyperliquid.is_paused()

--- a/tests/test_geofence.py
+++ b/tests/test_geofence.py
@@ -1,6 +1,8 @@
 """Tests for geofence list loading."""
 
 from hyperliquid_bot.bot.config import load_deny_countries
+from fastapi.testclient import TestClient
+import hyperliquid_bot.api.main as api_main
 
 
 def test_load_deny_countries_defaults(tmp_path, monkeypatch):
@@ -8,13 +10,39 @@ def test_load_deny_countries_defaults(tmp_path, monkeypatch):
     # Copy test file to temporary directory
     deny_file = tmp_path / "deny.json"
     deny_file.write_text('["IR", "kp", "Sy"]')
-    monkeypatch.setenv("DENY_COUNTRIES_PATH", str(deny_file))
+    monkeypatch.setenv("DENY_COUNTRIES_URL", deny_file.as_uri())
     codes = load_deny_countries()
     assert set(codes) == {"IR", "KP", "SY"}
 
 
-def test_load_deny_countries_missing(monkeypatch):
+def test_load_deny_countries_missing(tmp_path, monkeypatch):
     """When file does not exist, empty list is returned."""
-    monkeypatch.setenv("DENY_COUNTRIES_PATH", "/path/does/not/exist.json")
+    missing = tmp_path / "missing.json"
+    monkeypatch.setenv("DENY_COUNTRIES_URL", missing.as_uri())
     codes = load_deny_countries()
     assert codes == []
+
+
+def test_approve_callback_blocks(monkeypatch, tmp_path):
+    """Approval callback should block users from denied countries."""
+    deny_file = tmp_path / "deny.json"
+    deny_file.write_text('["IR", "KP"]')
+    monkeypatch.setenv("DENY_COUNTRIES_URL", deny_file.as_uri())
+
+    def fake_urlopen(url: str):
+        class Resp:
+            def read(self) -> bytes:
+                return b'{"country":"IR"}'
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        return Resp()
+
+    monkeypatch.setattr(api_main, "urlopen", fake_urlopen)
+    client = TestClient(api_main.app)
+    resp = client.post("/approve/callback", headers={"X-Forwarded-For": "1.2.3.4"})
+    assert resp.status_code == 403

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -3,21 +3,32 @@ from hyperliquid_bot.bot.commands import (
     buy_sell_handler,
     cancel_handler,
     positions_handler,
+    price_handler,
     start_handler,
+    order_callback_handler,
 )
 from hyperliquid_bot.bot.middleware import ExecutionTimeMiddleware
 from aiogram import types
+from hyperliquid_bot.bot.db import get_engine, get_sessionmaker, Trade
+from sqlalchemy import select
 
 
 class DummyMessage(types.Message):
     """Message object capturing answers for testing."""
 
-    def __init__(self, text: str = "") -> None:
-        super().__init__(text)
-        self.replies = []
+    def __init__(self, text: str = "", from_user: types.User | None = None) -> None:
+        super().__init__(text, from_user)
+        self.replies: list[str] = []
+        self.markups = []
 
-    async def answer(self, text: str) -> None:  # type: ignore[override]
+    async def answer(self, text: str, reply_markup=None) -> None:  # type: ignore[override]
         self.replies.append(text)
+        self.markups.append(reply_markup)
+        self.text = text
+
+    async def edit_text(self, text: str) -> None:  # type: ignore[override]
+        self.replies.append(text)
+        self.text = text
 
 
 def test_positions_handler_outputs_placeholder():
@@ -50,6 +61,10 @@ def set_env(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "o")
     monkeypatch.setenv("DATABASE_URL", "sqlite://")
     monkeypatch.setenv("REDIS_URL", "redis://")
+    monkeypatch.setenv("BUILDER_FEE_TENTH_BPS", "5")
+    monkeypatch.setenv("TOKEN_BUDGET_MONTHLY", "200")
+    monkeypatch.setenv("VOICE_ENABLED", "false")
+    monkeypatch.setenv("DENY_COUNTRIES_URL", "")
 
 
 def test_start_handler(monkeypatch):
@@ -92,4 +107,31 @@ def test_buy_sell_handler_success(monkeypatch):
     msg = DummyMessage("/buy ETH 1 2 3")
     asyncio.run(buy_sell_handler(msg, "buy"))
     assert "Order preview" in msg.replies[-1]
+    assert msg.markups[-1] is not None
+
+
+def test_price_handler(monkeypatch):
+    set_env(monkeypatch)
+    msg = DummyMessage("/price ETH")
+    asyncio.run(price_handler(msg))
+    assert "ETH price" in msg.replies[-1]
+
+
+def test_trade_row_created_after_buy(monkeypatch, tmp_path):
+    set_env(monkeypatch)
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/test.db"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    user = types.User(7)
+    msg = DummyMessage("/buy ETH 1", from_user=user)
+    asyncio.run(buy_sell_handler(msg, "buy"))
+    cb = types.CallbackQuery("confirm", msg, from_user=user)
+    asyncio.run(order_callback_handler(cb))
+    get_engine()
+    sessionmaker = get_sessionmaker()
+    async def fetch_symbol() -> str:
+        async with sessionmaker() as session:
+            result = await session.execute(select(Trade))
+            return result.scalar_one().symbol
+    symbol = asyncio.run(fetch_symbol())
+    assert symbol == "ETH"
 

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -6,6 +6,8 @@ from aiogram.test_utils import TestDispatcher
 
 from hyperliquid_bot.bot.commands import setup_bot
 from hyperliquid_bot.bot.middleware import ExecutionTimeMiddleware
+from fastapi.testclient import TestClient
+from hyperliquid_bot.api.main import app
 
 
 def set_env(monkeypatch):
@@ -13,6 +15,10 @@ def set_env(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "o")
     monkeypatch.setenv("DATABASE_URL", "sqlite://")
     monkeypatch.setenv("REDIS_URL", "redis://")
+    monkeypatch.setenv("BUILDER_FEE_TENTH_BPS", "5")
+    monkeypatch.setenv("TOKEN_BUDGET_MONTHLY", "200")
+    monkeypatch.setenv("VOICE_ENABLED", "false")
+    monkeypatch.setenv("DENY_COUNTRIES_URL", "")
 
 
 def test_latency(monkeypatch):
@@ -35,3 +41,11 @@ def test_latency(monkeypatch):
     p95 = sorted(timings)[int(len(timings) * 0.95) - 1]
     print(f"Average latency: {avg*1000:.2f} ms; p95 latency: {p95*1000:.2f} ms")
     assert p95 < 0.4
+
+
+def test_metrics_endpoint_200():
+    client = TestClient(app)
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    assert "total_orders" in resp.text
+    assert "latency_ms_bucket" in resp.text


### PR DESCRIPTION
## Summary
- Add SQLAlchemy `User` and `Trade` models with async session helpers
- Persist trades on order confirmation and count orders for metrics
- Enforce geofence on approval callback and expose Prometheus `/metrics`

## Testing
- `flake8`
- `pytest --cov=hyperliquid_bot --cov=tests --cov-fail-under=85`


------
https://chatgpt.com/codex/tasks/task_e_6890e2fed1e48321815c13e8dec02a2d