### PR TITLE
feat: add breaker pause and alert

### DIFF
--- a/hyperliquid_bot/bot/commands.py
+++ b/hyperliquid_bot/bot/commands.py
@@ -16,7 +16,7 @@ from aiogram import Bot, Dispatcher, types
 from aiogram.filters import CommandStart, CommandObject
 
 from .config import load_deny_countries
-from .hyperliquid import build_order_json
+from . import hyperliquid
 
 
 logger = logging.getLogger(__name__)
@@ -84,8 +84,15 @@ async def buy_sell_handler(message: types.Message, side: str) -> None:
         except ValueError:
             await message.answer("Invalid leverage; please provide an integer.")
             return
+    if hyperliquid.is_paused():
+        await message.answer(
+            "Trading is temporarily paused due to earlier errors. Please try again later."
+        )
+        return
     # Build order payload
-    payload = build_order_json(symbol=symbol, side=side, size=size, price=price, leverage=leverage)
+    payload = hyperliquid.build_order_json(
+        symbol=symbol, side=side, size=size, price=price, leverage=leverage
+    )
     # Show preview to user
     await message.answer(
         f"Order preview:\n{payload}\n\nReply 'yes' to confirm or 'no' to cancel."

--- a/tests/test_breaker.py
+++ b/tests/test_breaker.py
@@ -1,0 +1,15 @@
+from hyperliquid_bot.bot import hyperliquid
+
+
+def test_record_api_error_alert():
+    hyperliquid.reset_breaker()
+    alerts = []
+
+    def cb(msg: str) -> None:
+        alerts.append(msg)
+
+    hyperliquid.set_alert_callback(cb)
+    for _ in range(3):
+        hyperliquid.record_api_error()
+    assert hyperliquid.is_paused() is True
+    assert alerts and "error threshold" in alerts[0].lower()


### PR DESCRIPTION
## Summary
- add circuit breaker state with alert callback for Hyperliquid API errors
- block buy/sell commands when trading is paused
- test breaker alert and pause behavior

## Testing
- `pytest --cov=hyperliquid_bot`

------
https://chatgpt.com/codex/tasks/task_e_6891e99c85a08321a4af2bc4023e57c8